### PR TITLE
Change HTTP handler API for clearer mem management

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,31 +55,33 @@ the request will timeout, you can keep using the
 `replyFn` indefinetly(?) though.
 
 ```
-const Slacktion = require('./slacktion')
+const Slacktion = require('../lib/slacktion')
 
-const slacktion = new Slacktion()
+module.exports.bot1 = function(req, resp) {
+  const slacktion = new Slacktion()
 
-slacktion.registerAction({
-  name: 'add',
-  description: 'Adds two numbers',
-  args: [{name: 'x', optional: false}, {name: 'y', optional: false}],
-  fn: async(username, replyFn, x, y) => {
-    await replyFn('Adding ' + x + ' and ' + y)
-    return parseInt(x) + parseInt(y)
-  }
-})
+  slacktion.registerAction({
+    name: 'add',
+    description: 'Adds two numbers',
+    args: [{name: 'x', optional: false}, {name: 'y', optional: false}],
+    fn: async(username, replyFn, x, y) => {
+      await replyFn('Adding ' + x + ' and ' + y)
+      return parseInt(x) + parseInt(y)
+    }
+  })
 
-slacktion.registerAction({
-  name: 'sub',
-  description: 'Subtracts two numbers',
-  args: [{name: 'x', optional: false}, {name: 'y', optional: false}],
-  fn: async(username, replyFn, x, y) => {
-    await replyFn('subtracting ' + x + ' and ' + y)
-    return parseInt(x) - parseInt(y)
-  }
-})
+  slacktion.registerAction({
+    name: 'sub',
+    description: 'Subtracts two numbers',
+    args: [{name: 'x', optional: false}, {name: 'y', optional: false}],
+    fn: async(username, replyFn, x, y) => {
+      await replyFn('subtracting ' + x + ' and ' + y)
+      return parseInt(x) - parseInt(y)
+    }
+  })
 
-module.exports.bot1 = slacktion.getExportFunction()
+  return slacktion.handleHttpRequest(req, resp)
+}
 ```
 
 ## Exposed functions

--- a/examples/httpExample.js
+++ b/examples/httpExample.js
@@ -1,25 +1,27 @@
 const Slacktion = require('../lib/slacktion')
 
-const slacktion = new Slacktion()
+module.exports.bot1 = function(req, resp) {
+  const slacktion = new Slacktion()
 
-slacktion.registerAction({
-  name: 'add',
-  description: 'Adds two numbers',
-  args: [{name: 'x', optional: false}, {name: 'y', optional: false}],
-  fn: async(username, replyFn, x, y) => {
-    await replyFn('Adding ' + x + ' and ' + y)
-    return parseInt(x) + parseInt(y)
-  }
-})
+  slacktion.registerAction({
+    name: 'add',
+    description: 'Adds two numbers',
+    args: [{name: 'x', optional: false}, {name: 'y', optional: false}],
+    fn: async(username, replyFn, x, y) => {
+      await replyFn('Adding ' + x + ' and ' + y)
+      return parseInt(x) + parseInt(y)
+    }
+  })
 
-slacktion.registerAction({
-  name: 'sub',
-  description: 'Subtracts two numbers',
-  args: [{name: 'x', optional: false}, {name: 'y', optional: false}],
-  fn: async(username, replyFn, x, y) => {
-    await replyFn('subtracting ' + x + ' and ' + y)
-    return parseInt(x) - parseInt(y)
-  }
-})
+  slacktion.registerAction({
+    name: 'sub',
+    description: 'Subtracts two numbers',
+    args: [{name: 'x', optional: false}, {name: 'y', optional: false}],
+    fn: async(username, replyFn, x, y) => {
+      await replyFn('subtracting ' + x + ' and ' + y)
+      return parseInt(x) - parseInt(y)
+    }
+  })
 
-module.exports.bot1 = slacktion.getExportFunction()
+  return slacktion.handleHttpRequest(req, resp)
+}

--- a/lib/slacktion.js
+++ b/lib/slacktion.js
@@ -33,15 +33,10 @@ class Slacktion {
     })
   }
 
-  getExportFunction() {
-    if (this.rtmBot) {
-      throw Error('Exportfunction not applicable for RTM bots')
-    }
-    return (req, resp) => {
-      this._dispatchAction(parseMessage(req.body.text), req.body.user_name, req.body.response_url)
-        .then(res => resp.status(200).send(res + '')) // Slack intreprets ints as response codes
-        .catch(err => resp.status(200).send((err.message || err) + ''))
-    }
+  handleHttpRequest(req, resp) {
+    return this._dispatchAction(parseMessage(req.body.text), req.body.user_name, req.body.response_url)
+      .then(res => resp.status(200).send(res + '')) // Slack intreprets ints as response codes
+      .catch(err => resp.status(200).send((err.message || err) + ''))
   }
 
   _handleMessage(message) {


### PR DESCRIPTION
With the old API and usage where the export function of a GCF is set to `slacktion.getExportFunction()` the `slacktion` variable goes out of scope and the instance is being kept alive by the `this` reference in the returned function.

This makes for a more confusing and harder to reason about memory management which can often lead to problems down the road. It's better to be more explicit about who is owning the strong reference.

Changing this also mean we can remove a check for the type of Slacktion (HTTP or RTM since the API doesn't make sense to call without HTTP request and response objects).